### PR TITLE
feat: Add server-side permission checking mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+All notable changes to ab0t-auth will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- **Server-side permission checking mode** (`permission_check_mode`)
+  - New configuration option to switch between client-side (JWT claims) and server-side (API call) permission verification
+  - Environment variable: `AB0T_AUTH_PERMISSION_CHECK_MODE=server`
+  - Programmatic: `AuthGuard(auth_url="...", permission_check_mode="server")`
+  - Default is `"client"` for backward compatibility
+  - Server mode calls `/permissions/check` endpoint for authoritative, real-time verification
+  - Enables instant permission revocation without waiting for JWT expiration
+
+### Why Server Mode?
+
+The Ab0t auth service intentionally stores permissions in the database rather than JWT tokens. This design supports:
+
+1. **Instant revocation** - Permissions can be removed immediately without waiting for token expiry
+2. **Dynamic org scoping** - Permissions can vary by organization context
+3. **Role-based inheritance** - Roles expand to permissions at check time
+4. **Real-time updates** - Permission changes take effect immediately
+
+**Recommendation:** Services using `auth.service.ab0t.com` should enable server mode:
+
+```bash
+AB0T_AUTH_PERMISSION_CHECK_MODE=server
+```
+
+This ensures permission checks are authoritative and reflect the latest state.
+
+## [0.1.0] - 2026-01-15
+
+### Added
+
+- Initial release
+- JWT validation with JWKS
+- API key authentication
+- Permission checking (client-side)
+- FastAPI dependencies (`require_auth`, `require_permission`, etc.)
+- FastAPI middleware (`AuthMiddleware`)
+- FastAPI decorators (`@protected`, `@permission_required`, etc.)
+- Token caching with TTL
+- JWKS caching with auto-refresh
+- Structured logging
+- Flask support (`Ab0tAuth` extension)
+- Multi-tenancy with nested organizations
+- Auth bypass for testing/development
+- Check callbacks for dynamic authorization

--- a/demo/README.md
+++ b/demo/README.md
@@ -35,10 +35,15 @@ Edit the `AUTH_URL` in either server file to point to your Ab0t auth service:
 AUTH_URL = "https://auth.service.ab0t.com"  # Your Ab0t auth URL
 ```
 
-Or set via environment variable:
+Or set via environment variables:
 
 ```bash
 export AB0T_AUTH_URL="https://auth.service.ab0t.com"
+
+# Recommended: Enable server-side permission checking
+# This calls /permissions/check for authoritative verification
+# Supports instant permission revocation without waiting for JWT expiry
+export AB0T_AUTH_PERMISSION_CHECK_MODE="server"
 ```
 
 ---

--- a/demo/fastapi_server.py
+++ b/demo/fastapi_server.py
@@ -37,6 +37,14 @@ from ab0t_auth.decorators import (
 AUTH_URL = "https://auth.service.ab0t.com"  # Replace with your Ab0t auth URL
 
 # Initialize auth guard
+# NOTE: For production with auth.service.ab0t.com, use permission_check_mode="server"
+# This enables real-time permission verification via /permissions/check endpoint,
+# supporting instant permission revocation without waiting for JWT expiry.
+#
+# Set via env var: AB0T_AUTH_PERMISSION_CHECK_MODE=server
+# Or programmatically:
+#   auth = AuthGuard(auth_url=AUTH_URL, permission_check_mode="server")
+#
 auth = AuthGuard(auth_url=AUTH_URL)
 
 

--- a/src/ab0t_auth/config.py
+++ b/src/ab0t_auth/config.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from functools import lru_cache
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -178,6 +178,12 @@ class AuthSettings(BaseSettings):
         description="Enable debug logging",
     )
 
+    # Permission verification mode
+    permission_check_mode: Literal["client", "server"] = Field(
+        default="client",
+        description="Permission check mode: 'client' (JWT claims) or 'server' (API call)",
+    )
+
     @field_validator("auth_url")
     @classmethod
     def validate_auth_url(cls, v: str) -> str:
@@ -233,6 +239,7 @@ def settings_to_config(settings: AuthSettings) -> AuthConfig:
         enable_api_key_auth=settings.enable_api_key_auth,
         enable_jwt_auth=settings.enable_jwt_auth,
         debug=settings.debug,
+        permission_check_mode=settings.permission_check_mode,
     )
 
 
@@ -247,6 +254,7 @@ def create_config(
     token_cache_ttl: int = 60,
     verify_exp: bool = True,
     debug: bool = False,
+    permission_check_mode: Literal["client", "server"] = "client",
     **kwargs: Any,
 ) -> AuthConfig:
     """
@@ -264,6 +272,7 @@ def create_config(
         token_cache_ttl=token_cache_ttl,
         verify_exp=verify_exp,
         debug=debug,
+        permission_check_mode=permission_check_mode,
         **kwargs,
     )
 

--- a/src/ab0t_auth/core.py
+++ b/src/ab0t_auth/core.py
@@ -183,6 +183,10 @@ class AuthConfig:
     enable_api_key_auth: bool = True
     enable_jwt_auth: bool = True
     debug: bool = False
+    # Permission verification mode:
+    # - "client": Check JWT claims only (default, fast)
+    # - "server": Call /permissions/check endpoint (authoritative, real-time)
+    permission_check_mode: Literal["client", "server"] = "client"
 
 
 # =============================================================================

--- a/src/ab0t_auth/guard.py
+++ b/src/ab0t_auth/guard.py
@@ -8,7 +8,7 @@ Similar to slowapi's Limiter - provides the main interface for the library.
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
-from typing import Any, AsyncIterator
+from typing import Any, AsyncIterator, Literal
 
 import httpx
 from jwt import PyJWKClient
@@ -91,6 +91,7 @@ class AuthGuard:
         audience: str | tuple[str, ...] | None = None,
         issuer: str | None = None,
         debug: bool = False,
+        permission_check_mode: Literal["client", "server"] = "client",
     ) -> None:
         """
         Initialize AuthGuard.
@@ -116,6 +117,7 @@ class AuthGuard:
                 audience=audience,
                 issuer=issuer,
                 debug=debug,
+                permission_check_mode=permission_check_mode,
             )
         else:
             raise ConfigurationError(

--- a/tests/test_check_callback.py
+++ b/tests/test_check_callback.py
@@ -69,6 +69,9 @@ def mock_guard(test_user: AuthenticatedUser):
     guard.config = MagicMock()
     guard.config.api_key_header = "X-API-Key"
     guard.config.header_name = "Authorization"
+    # For server-side permission checking mode support
+    guard._config = MagicMock()
+    guard._config.permission_check_mode = "client"
 
     async def mock_authenticate(auth, api_key):
         from ab0t_auth.core import AuthResult

--- a/tests/test_server_permission_mode.py
+++ b/tests/test_server_permission_mode.py
@@ -1,0 +1,295 @@
+"""
+Tests for server-side permission checking mode.
+
+Tests the `permission_check_mode` configuration that switches between
+client-side (JWT claims) and server-side (/permissions/check API) verification.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import FastAPI, Depends, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from ab0t_auth.core import (
+    AuthConfig,
+    AuthenticatedUser,
+    AuthMethod,
+    AuthResult,
+    PermissionCheckResponse,
+    PermissionResult,
+    TokenType,
+)
+from ab0t_auth.errors import AuthError, PermissionDeniedError
+from ab0t_auth.guard import AuthGuard
+from ab0t_auth.dependencies import require_permission
+
+
+def add_exception_handlers(app: FastAPI) -> None:
+    """Add auth exception handlers to FastAPI app."""
+    @app.exception_handler(AuthError)
+    async def auth_error_handler(request: Request, exc: AuthError):
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={"detail": exc.message, "code": exc.code},
+        )
+
+
+# =============================================================================
+# Test Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def test_user() -> AuthenticatedUser:
+    """User with specific permissions for testing."""
+    return AuthenticatedUser(
+        user_id="user_123",
+        email="test@example.com",
+        org_id="org_abc",
+        permissions=("users:read", "reports:view"),  # Has users:read, NOT admin:access
+        roles=("user",),
+        auth_method=AuthMethod.JWT,
+        token_type=TokenType.BEARER,
+    )
+
+
+@pytest.fixture
+def mock_guard_client_mode(test_user: AuthenticatedUser):
+    """Mock AuthGuard in client mode (default)."""
+    guard = MagicMock(spec=AuthGuard)
+    guard.config = MagicMock()
+    guard.config.api_key_header = "X-API-Key"
+    guard.config.header_name = "Authorization"
+    guard._config = MagicMock()
+    guard._config.permission_check_mode = "client"
+
+    async def mock_authenticate_or_raise(auth, api_key):
+        return test_user
+
+    guard.authenticate_or_raise = AsyncMock(side_effect=mock_authenticate_or_raise)
+    return guard
+
+
+@pytest.fixture
+def mock_guard_server_mode(test_user: AuthenticatedUser):
+    """Mock AuthGuard in server mode."""
+    guard = MagicMock(spec=AuthGuard)
+    guard.config = MagicMock()
+    guard.config.api_key_header = "X-API-Key"
+    guard.config.header_name = "Authorization"
+    guard._config = MagicMock()
+    guard._config.permission_check_mode = "server"
+    guard._http_client = MagicMock()
+    guard._permission_cache = MagicMock()
+    guard._permission_cache.get = MagicMock(return_value=None)  # No cache hit
+
+    async def mock_authenticate_or_raise(auth, api_key):
+        return test_user
+
+    guard.authenticate_or_raise = AsyncMock(side_effect=mock_authenticate_or_raise)
+    return guard
+
+
+# =============================================================================
+# Test Client Mode (Default Behavior)
+# =============================================================================
+
+
+class TestClientModePermissionCheck:
+    """Tests for client-side permission checking (JWT claims)."""
+
+    def test_permission_granted_from_claims(self, mock_guard_client_mode: AuthGuard):
+        """Permission check passes when user has permission in JWT claims."""
+        app = FastAPI()
+
+        @app.get("/users")
+        async def get_users(
+            user: AuthenticatedUser = Depends(require_permission(
+                mock_guard_client_mode,
+                "users:read",
+            )),
+        ):
+            return {"user_id": user.user_id, "mode": "client"}
+
+        client = TestClient(app)
+        response = client.get("/users", headers={"Authorization": "Bearer token"})
+
+        assert response.status_code == 200
+        assert response.json()["user_id"] == "user_123"
+
+    def test_permission_denied_from_claims(self, mock_guard_client_mode: AuthGuard):
+        """Permission check fails when user lacks permission in JWT claims."""
+        app = FastAPI()
+        add_exception_handlers(app)
+
+        @app.get("/admin")
+        async def admin_only(
+            user: AuthenticatedUser = Depends(require_permission(
+                mock_guard_client_mode,
+                "admin:access",  # User doesn't have this
+            )),
+        ):
+            return {"admin": True}
+
+        client = TestClient(app)
+        response = client.get("/admin", headers={"Authorization": "Bearer token"})
+
+        assert response.status_code == 403
+        assert "admin:access" in response.json()["detail"]
+
+
+# =============================================================================
+# Test Server Mode (API Call to /permissions/check)
+# =============================================================================
+
+
+class TestServerModePermissionCheck:
+    """Tests for server-side permission checking (API call)."""
+
+    def test_permission_granted_from_server(self, mock_guard_server_mode: AuthGuard, test_user: AuthenticatedUser):
+        """Permission check passes when server grants permission."""
+        app = FastAPI()
+
+        # Mock verify_permission to return allowed
+        with patch("ab0t_auth.dependencies.verify_permission") as mock_verify:
+            mock_verify.return_value = PermissionResult.grant("admin:access")
+
+            @app.get("/admin")
+            async def admin_only(
+                user: AuthenticatedUser = Depends(require_permission(
+                    mock_guard_server_mode,
+                    "admin:access",  # User doesn't have in JWT, but server grants
+                )),
+            ):
+                return {"admin": True, "user_id": user.user_id}
+
+            client = TestClient(app)
+            response = client.get("/admin", headers={"Authorization": "Bearer token"})
+
+            assert response.status_code == 200
+            assert response.json()["admin"] is True
+
+            # Verify the server-side check was called
+            mock_verify.assert_called_once()
+
+    def test_permission_denied_from_server(self, mock_guard_server_mode: AuthGuard, test_user: AuthenticatedUser):
+        """Permission check fails when server denies permission."""
+        app = FastAPI()
+        add_exception_handlers(app)
+
+        # Mock verify_permission to return denied
+        with patch("ab0t_auth.dependencies.verify_permission") as mock_verify:
+            mock_verify.return_value = PermissionResult.deny(
+                "admin:access",
+                "User does not have this permission",
+            )
+
+            @app.get("/admin")
+            async def admin_only(
+                user: AuthenticatedUser = Depends(require_permission(
+                    mock_guard_server_mode,
+                    "admin:access",
+                )),
+            ):
+                return {"admin": True}
+
+            client = TestClient(app)
+            response = client.get("/admin", headers={"Authorization": "Bearer token"})
+
+            assert response.status_code == 403
+            mock_verify.assert_called_once()
+
+    def test_server_mode_overrides_jwt_claims(self, mock_guard_server_mode: AuthGuard, test_user: AuthenticatedUser):
+        """
+        Server mode is authoritative - can deny even if JWT has the permission.
+
+        This is the key use case: permissions can be revoked instantly on the
+        server without waiting for JWT expiration.
+        """
+        app = FastAPI()
+        add_exception_handlers(app)
+
+        # User has users:read in JWT claims, but server denies it
+        with patch("ab0t_auth.dependencies.verify_permission") as mock_verify:
+            mock_verify.return_value = PermissionResult.deny(
+                "users:read",
+                "Permission revoked by admin",
+            )
+
+            @app.get("/users")
+            async def get_users(
+                user: AuthenticatedUser = Depends(require_permission(
+                    mock_guard_server_mode,
+                    "users:read",  # User HAS this in JWT, but server denies
+                )),
+            ):
+                return {"users": []}
+
+            client = TestClient(app)
+            response = client.get("/users", headers={"Authorization": "Bearer token"})
+
+            # Should be denied despite having permission in JWT
+            assert response.status_code == 403
+            mock_verify.assert_called_once()
+
+
+# =============================================================================
+# Test Configuration
+# =============================================================================
+
+
+class TestPermissionCheckModeConfig:
+    """Tests for permission_check_mode configuration."""
+
+    def test_default_mode_is_client(self):
+        """Default permission_check_mode should be 'client'."""
+        config = AuthConfig(auth_url="https://auth.example.com")
+        assert config.permission_check_mode == "client"
+
+    def test_can_set_server_mode(self):
+        """Can explicitly set permission_check_mode to 'server'."""
+        config = AuthConfig(
+            auth_url="https://auth.example.com",
+            permission_check_mode="server",
+        )
+        assert config.permission_check_mode == "server"
+
+    def test_guard_accepts_mode_parameter(self):
+        """AuthGuard accepts permission_check_mode in constructor."""
+        guard = AuthGuard(
+            auth_url="https://auth.example.com",
+            permission_check_mode="server",
+        )
+        assert guard._config.permission_check_mode == "server"
+
+    def test_guard_defaults_to_client_mode(self):
+        """AuthGuard defaults to client mode."""
+        guard = AuthGuard(auth_url="https://auth.example.com")
+        assert guard._config.permission_check_mode == "client"
+
+
+# =============================================================================
+# Test Environment Variable Configuration
+# =============================================================================
+
+
+class TestPermissionCheckModeEnvVar:
+    """Tests for AB0T_AUTH_PERMISSION_CHECK_MODE environment variable."""
+
+    def test_env_var_sets_server_mode(self, monkeypatch):
+        """AB0T_AUTH_PERMISSION_CHECK_MODE=server enables server mode."""
+        monkeypatch.setenv("AB0T_AUTH_PERMISSION_CHECK_MODE", "server")
+
+        from ab0t_auth.config import AuthSettings
+        settings = AuthSettings()
+
+        assert settings.permission_check_mode == "server"
+
+    def test_env_var_defaults_to_client(self):
+        """Without env var, defaults to client mode."""
+        from ab0t_auth.config import AuthSettings
+        settings = AuthSettings()
+
+        assert settings.permission_check_mode == "client"


### PR DESCRIPTION
## Summary

- Add `permission_check_mode` config option to switch between client-side (JWT claims) and server-side (API call) permission verification
- Server mode calls `/permissions/check` endpoint for authoritative, real-time checks
- Enables instant permission revocation without waiting for JWT expiry
- Default is "client" for backward compatibility

## Problem

The Ab0t auth service intentionally stores permissions in the database (not in JWT tokens) to support:
- **Instant revocation** - Permissions can be removed immediately
- **Dynamic org scoping** - Permissions vary by organization context  
- **Role-based inheritance** - Roles expand to permissions at check time

Previously, `require_permission()` only checked JWT claims, which couldn't reflect permission changes until token expiry.

## Solution

Add configurable `permission_check_mode`:

```bash
# Environment variable
AB0T_AUTH_PERMISSION_CHECK_MODE=server
```

```python
# Or programmatically
auth = AuthGuard(auth_url="...", permission_check_mode="server")
```

## Changes

- `core.py`: Add `permission_check_mode` to `AuthConfig`
- `config.py`: Add to `AuthSettings` with env var support
- `dependencies.py`: Update `require_permission`, `require_any_permission`, `require_all_permissions`
- `guard.py`: Accept `permission_check_mode` in constructor
- New test file with 11 test cases
- Updated README, demo docs, added CHANGELOG

## Test plan

- [x] All 398 tests pass (387 existing + 11 new)
- [x] Server mode correctly calls `verify_permission()` 
- [x] Client mode (default) unchanged
- [x] Environment variable configuration works
- [x] Backward compatible - no breaking changes

---

🤖 Generated with ab0t-core