### PR TITLE
security(guard): surface + opt-in enforce JWT audience verification (ISSUE-017)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security Fixes
 
+- **HIGH: JWT audience verification can no longer be silently disabled in production** (`guard.py`) — ISSUE-017
+  - When no `audience` was configured, `validate_token_local` set the PyJWT `verify_aud` option to `False`
+    (`verify_aud = verify_aud and audience is not None`), so a token minted for **any** mesh service was
+    accepted as this service's caller — cross-service token confusion
+  - New `AuthGuard._enforce_audience_security()` runs at construction: it **always warns** when audience
+    verification is off, and **fails closed** (`ConfigurationError`) when `ENVIRONMENT` /
+    `AB0T_AUTH_ENVIRONMENT` is `production`/`prod`/`staging` and `AB0T_AUTH_DEBUG` is not set
+  - Deliberately **non-breaking on upgrade**: dev/test/unset environments are warn-only; only a production
+    deployment with no audience is stopped. Mirrors the auth-bypass defense-in-depth
+  - **Rollout:** each mesh consumer must set `AB0T_AUTH_AUDIENCE` before this reaches its prod environment
+  - Reported by: Resource-service security audit (R-M2)
+
 - **CRITICAL: API key validation no longer hardcodes `valid=True`** (`client.py`)
   - `validate_api_key()` previously ignored the `valid` field from the auth service response and hardcoded `True` for any HTTP 200 — meaning **any string** as `X-API-Key` was accepted
   - Now reads `data.get("valid", False)` — fail-closed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Security Fixes
+### Added
 
-- **HIGH: JWT audience verification can no longer be silently disabled in production** (`guard.py`) — ISSUE-017
-  - When no `audience` was configured, `validate_token_local` set the PyJWT `verify_aud` option to `False`
-    (`verify_aud = verify_aud and audience is not None`), so a token minted for **any** mesh service was
-    accepted as this service's caller — cross-service token confusion
-  - New `AuthGuard._enforce_audience_security()` runs at construction: it **always warns** when audience
-    verification is off, and **fails closed** (`ConfigurationError`) when `ENVIRONMENT` /
-    `AB0T_AUTH_ENVIRONMENT` is `production`/`prod`/`staging` and `AB0T_AUTH_DEBUG` is not set
-  - Deliberately **non-breaking on upgrade**: dev/test/unset environments are warn-only; only a production
-    deployment with no audience is stopped. Mirrors the auth-bypass defense-in-depth
-  - **Rollout:** each mesh consumer must set `AB0T_AUTH_AUDIENCE` before this reaches its prod environment
-  - Reported by: Resource-service security audit (R-M2)
+- **Audience-verification safety net on `AuthGuard`** (`guard.py`) — ISSUE-017
+  - **Context (the exposure):** when no `audience` is configured, `validate_token_local` sets PyJWT's
+    `verify_aud` option to `False` (`verify_aud = verify_aud and audience is not None`), so a token minted
+    for **any** mesh service is accepted as this service's caller — silent cross-service token confusion.
+  - **Always-on warning (non-breaking):** `AuthGuard` now logs a loud `warning` event
+    (`audience_verification_disabled`) at construction whenever audience verification is off. Construction
+    still succeeds — **no behaviour change for existing consumers.**
+  - **Opt-in fail-closed:** new constructor kwarg `require_audience: bool = False` and env var
+    `AB0T_AUTH_REQUIRE_AUDIENCE`. When enabled, an audience-less configuration raises `ConfigurationError`
+    at construction. **Off by default** (mirrors the opt-in auth-bypass philosophy — the stricter posture is
+    never imposed). Recommended `AB0T_AUTH_REQUIRE_AUDIENCE=true` in production once `AB0T_AUTH_AUDIENCE` is set.
+  - Backward compatible (minor): existing `AuthGuard(...)` calls are unchanged; only new optional surface is
+    added. Making `require_audience` default `True` would be a future, separately-documented **major** change.
+  - Reported by: Resource-service security audit (R-M2).
+
+### Security Fixes
 
 - **CRITICAL: API key validation no longer hardcodes `valid=True`** (`client.py`)
   - `validate_api_key()` previously ignored the `valid` field from the auth service response and hardcoded `True` for any HTTP 200 — meaning **any string** as `X-API-Key` was accepted

--- a/src/ab0t_auth/guard.py
+++ b/src/ab0t_auth/guard.py
@@ -93,6 +93,7 @@ class AuthGuard:
         issuer: str | None = None,
         debug: bool = False,
         permission_check_mode: Literal["client", "server"] = "client",
+        require_audience: bool = False,
     ) -> None:
         """
         Initialize AuthGuard.
@@ -105,6 +106,11 @@ class AuthGuard:
             audience: Expected JWT audience
             issuer: Expected JWT issuer
             debug: Enable debug logging
+            require_audience: Opt-in fail-closed. When True (or the env var
+                ``AB0T_AUTH_REQUIRE_AUDIENCE=true`` is set), constructing the guard
+                without a verified audience raises ``ConfigurationError`` instead of
+                running with audience verification disabled. Default False preserves
+                existing behaviour; a loud warning is emitted either way.
         """
         # Build configuration
         if config:
@@ -142,17 +148,15 @@ class AuthGuard:
         self._logger = get_logger("ab0t_auth.guard")
         self._metrics = AuthMetrics()
 
-        # Fail-closed: audience verification must not be silently disabled in prod.
-        self._enforce_audience_security()
+        # Surface (and, if opted in, refuse) a silently-disabled audience check.
+        self._require_audience = require_audience
+        self._warn_or_require_audience()
 
         # State tracking
         self._initialized = False
 
-    # Environments in which an audience-less configuration is a hard error.
-    _PRODLIKE_ENVIRONMENTS = ("production", "prod", "staging")
-
-    def _enforce_audience_security(self) -> None:
-        """Guard against silently accepting ANY audience.
+    def _warn_or_require_audience(self) -> None:
+        """Surface a silently-disabled JWT audience check.
 
         When ``audience`` is unset (or ``verify_aud`` is False), PyJWT does NOT
         check the token's ``aud`` claim (see ``validate_token_local`` /
@@ -161,16 +165,16 @@ class AuthGuard:
         service being replayed against this one — with it off, any validly-signed
         token from any service in the mesh is accepted as this service's caller.
 
-        Two-tier, deliberately NON-BREAKING on upgrade:
+        BACKWARD-COMPATIBLE by design — the default never changes existing behaviour:
 
         * ALWAYS: emit a loud warning when audience verification is disabled, so
-          the exposure is visible in every environment.
-        * FAIL-CLOSED: raise ``ConfigurationError`` at construction ONLY when the
-          service declares a production/staging environment (the ambient
-          ``ENVIRONMENT`` / ``AB0T_AUTH_ENVIRONMENT`` the service already sets)
-          and ``AB0T_AUTH_DEBUG`` is not set. A dev/test/unset environment is
-          warn-only, so existing consumers are not broken by upgrading the library
-          — only a prod deployment that forgot its audience is stopped.
+          the exposure is visible. Construction still succeeds (default).
+        * OPT-IN fail-closed: if ``require_audience=True`` (constructor) or the env
+          var ``AB0T_AUTH_REQUIRE_AUDIENCE=true`` is set, raise ``ConfigurationError``
+          instead of running audience-less. This is off by default so upgrading the
+          library cannot break any existing consumer; a security-conscious service
+          (or a deployment's prod config) opts in explicitly — mirroring how the
+          auth-bypass feature is opt-in rather than imposed.
 
         Set the service's audience (``AB0T_AUTH_AUDIENCE`` / ``audience=``) to
         clear this. It is a no-op once audience verification is on.
@@ -179,30 +183,27 @@ class AuthGuard:
         if cfg.verify_aud and cfg.audience is not None:
             return  # audience is verified — safe, nothing to do
 
-        # Audience verification is OFF — always make it visible.
+        # Audience verification is OFF — always make it visible (non-breaking).
         self._logger.warning(
             "audience_verification_disabled",
             detail=(
                 "JWT audience is NOT verified (no audience configured). Tokens from "
                 "any mesh service will be accepted as this service's caller. Set "
-                "AB0T_AUTH_AUDIENCE to this service's audience. This is a hard error "
-                "when ENVIRONMENT is production/staging."
+                "AB0T_AUTH_AUDIENCE to this service's audience, or set "
+                "AB0T_AUTH_REQUIRE_AUDIENCE=true to make this a hard error."
             ),
         )
 
-        env = (
-            os.getenv("AB0T_AUTH_ENVIRONMENT")
-            or os.getenv("ENVIRONMENT")
-            or ""
-        ).strip().lower()
-        debug = bool(cfg.debug) or os.getenv("AB0T_AUTH_DEBUG", "").lower() == "true"
-        if env in self._PRODLIKE_ENVIRONMENTS and not debug:
+        require = self._require_audience or (
+            os.getenv("AB0T_AUTH_REQUIRE_AUDIENCE", "").lower() == "true"
+        )
+        if require:
             raise ConfigurationError(
-                "JWT audience verification is DISABLED (no audience configured) in a "
-                f"{env} environment: a token minted for ANY mesh service would be "
-                "accepted as this service's caller. Set this service's audience "
-                "(AB0T_AUTH_AUDIENCE / audience=...). Audience validation may only be "
-                "skipped outside production.",
+                "JWT audience verification is DISABLED (no audience configured) but "
+                "audience is required (require_audience / AB0T_AUTH_REQUIRE_AUDIENCE): "
+                "a token minted for ANY mesh service would otherwise be accepted as "
+                "this service's caller. Set this service's audience "
+                "(AB0T_AUTH_AUDIENCE / audience=...).",
                 config_key="audience",
             )
 

--- a/src/ab0t_auth/guard.py
+++ b/src/ab0t_auth/guard.py
@@ -7,6 +7,7 @@ Similar to slowapi's Limiter - provides the main interface for the library.
 
 from __future__ import annotations
 
+import os
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator, Literal
 
@@ -141,8 +142,69 @@ class AuthGuard:
         self._logger = get_logger("ab0t_auth.guard")
         self._metrics = AuthMetrics()
 
+        # Fail-closed: audience verification must not be silently disabled in prod.
+        self._enforce_audience_security()
+
         # State tracking
         self._initialized = False
+
+    # Environments in which an audience-less configuration is a hard error.
+    _PRODLIKE_ENVIRONMENTS = ("production", "prod", "staging")
+
+    def _enforce_audience_security(self) -> None:
+        """Guard against silently accepting ANY audience.
+
+        When ``audience`` is unset (or ``verify_aud`` is False), PyJWT does NOT
+        check the token's ``aud`` claim (see ``validate_token_local`` /
+        ``jwt.py``: ``verify_aud = verify_aud and audience is not None``). The
+        audience claim is the boundary that stops a JWT minted for ANOTHER mesh
+        service being replayed against this one — with it off, any validly-signed
+        token from any service in the mesh is accepted as this service's caller.
+
+        Two-tier, deliberately NON-BREAKING on upgrade:
+
+        * ALWAYS: emit a loud warning when audience verification is disabled, so
+          the exposure is visible in every environment.
+        * FAIL-CLOSED: raise ``ConfigurationError`` at construction ONLY when the
+          service declares a production/staging environment (the ambient
+          ``ENVIRONMENT`` / ``AB0T_AUTH_ENVIRONMENT`` the service already sets)
+          and ``AB0T_AUTH_DEBUG`` is not set. A dev/test/unset environment is
+          warn-only, so existing consumers are not broken by upgrading the library
+          — only a prod deployment that forgot its audience is stopped.
+
+        Set the service's audience (``AB0T_AUTH_AUDIENCE`` / ``audience=``) to
+        clear this. It is a no-op once audience verification is on.
+        """
+        cfg = self._config
+        if cfg.verify_aud and cfg.audience is not None:
+            return  # audience is verified — safe, nothing to do
+
+        # Audience verification is OFF — always make it visible.
+        self._logger.warning(
+            "audience_verification_disabled",
+            detail=(
+                "JWT audience is NOT verified (no audience configured). Tokens from "
+                "any mesh service will be accepted as this service's caller. Set "
+                "AB0T_AUTH_AUDIENCE to this service's audience. This is a hard error "
+                "when ENVIRONMENT is production/staging."
+            ),
+        )
+
+        env = (
+            os.getenv("AB0T_AUTH_ENVIRONMENT")
+            or os.getenv("ENVIRONMENT")
+            or ""
+        ).strip().lower()
+        debug = bool(cfg.debug) or os.getenv("AB0T_AUTH_DEBUG", "").lower() == "true"
+        if env in self._PRODLIKE_ENVIRONMENTS and not debug:
+            raise ConfigurationError(
+                "JWT audience verification is DISABLED (no audience configured) in a "
+                f"{env} environment: a token minted for ANY mesh service would be "
+                "accepted as this service's caller. Set this service's audience "
+                "(AB0T_AUTH_AUDIENCE / audience=...). Audience validation may only be "
+                "skipped outside production.",
+                config_key="audience",
+            )
 
     # =========================================================================
     # Properties

--- a/tests/test_audience_security.py
+++ b/tests/test_audience_security.py
@@ -1,0 +1,77 @@
+"""
+Tests for the audience-verification fail-closed guard (AuthGuard).
+
+Security finding (resource-service audit R-M2, 2026-07): when ``audience`` is
+unset, PyJWT does NOT verify the token's ``aud`` claim
+(``validate_token_local``: ``verify_aud = verify_aud and audience is not None``),
+so a JWT minted for ANY mesh service is accepted as this service's caller. This
+is a library-wide exposure — every consumer that constructs an AuthGuard without
+an audience is affected.
+
+The fix is deliberately NON-BREAKING on upgrade: it ALWAYS warns when audience
+verification is disabled, but only RAISES ``ConfigurationError`` when the service
+declares a production/staging environment (ambient ``ENVIRONMENT`` /
+``AB0T_AUTH_ENVIRONMENT``) and ``AB0T_AUTH_DEBUG`` is not set. A dev/test/unset
+environment is warn-only, so existing consumers keep working.
+
+Negative-control law: the prod-refusal assertion fails if
+``_enforce_audience_security`` is reverted to a no-op.
+"""
+import pytest
+
+from ab0t_auth.errors import ConfigurationError
+from ab0t_auth.guard import AuthGuard
+
+AUD = "LOCAL:020caf72-d9cd-48b1-bbfc-2bc8c67f0cc5"
+URL = "https://auth.service.ab0t.com"
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    # Ensure no ambient env leaks into the tests.
+    for k in ("AB0T_AUTH_DEBUG", "AB0T_AUTH_BYPASS", "ENVIRONMENT", "AB0T_AUTH_ENVIRONMENT"):
+        monkeypatch.delenv(k, raising=False)
+
+
+class TestAudienceSecurity:
+    @pytest.mark.parametrize("env", ["production", "prod", "staging"])
+    def test_prodlike_without_audience_is_refused(self, monkeypatch, env):
+        """The core control: no audience in a prod-like env => refuse to construct.
+        RED if the guard is reverted (constructs wide open)."""
+        monkeypatch.setenv("ENVIRONMENT", env)
+        with pytest.raises(ConfigurationError) as ei:
+            AuthGuard(auth_url=URL)  # audience defaults to None
+        assert ei.value.details == {"config_key": "audience"}
+
+    def test_prod_via_ab0t_env_var_also_refused(self, monkeypatch):
+        """The AB0T_AUTH_ENVIRONMENT signal is honored the same as ENVIRONMENT."""
+        monkeypatch.setenv("AB0T_AUTH_ENVIRONMENT", "production")
+        with pytest.raises(ConfigurationError):
+            AuthGuard(auth_url=URL)
+
+    def test_prodlike_with_audience_constructs(self, monkeypatch):
+        """Fix does not over-block: a configured audience constructs fine in prod."""
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        guard = AuthGuard(auth_url=URL, audience=AUD)
+        assert guard.config.audience == AUD
+        assert guard.config.verify_aud is True
+
+    def test_prod_with_debug_is_allowed(self, monkeypatch):
+        """DEBUG escape hatch: audience-less is permitted even in prod when
+        AB0T_AUTH_DEBUG=true (dev-on-prod-config), matching the bypass pattern."""
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        monkeypatch.setenv("AB0T_AUTH_DEBUG", "true")
+        guard = AuthGuard(auth_url=URL)
+        assert guard.config.audience is None
+
+    def test_dev_without_audience_is_allowed_warn_only(self):
+        """NON-BREAKING: a dev/unset environment is warn-only, never a hard error —
+        so existing consumers are not broken by upgrading the library."""
+        guard = AuthGuard(auth_url=URL)  # no ENVIRONMENT, no audience
+        assert guard.config.audience is None
+
+    def test_prodlike_with_multi_audience_tuple_constructs(self, monkeypatch):
+        """A tuple audience (multi-aud service) also satisfies the guard in prod."""
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        guard = AuthGuard(auth_url=URL, audience=(AUD, "LOCAL:other"))
+        assert guard.config.audience == (AUD, "LOCAL:other")

--- a/tests/test_audience_security.py
+++ b/tests/test_audience_security.py
@@ -1,21 +1,24 @@
 """
-Tests for the audience-verification fail-closed guard (AuthGuard).
+Tests for the audience-verification safety net (AuthGuard).
 
 Security finding (resource-service audit R-M2, 2026-07): when ``audience`` is
-unset, PyJWT does NOT verify the token's ``aud`` claim
-(``validate_token_local``: ``verify_aud = verify_aud and audience is not None``),
-so a JWT minted for ANY mesh service is accepted as this service's caller. This
-is a library-wide exposure — every consumer that constructs an AuthGuard without
-an audience is affected.
+unset, PyJWT does NOT verify the token's ``aud`` claim (``validate_token_local``:
+``verify_aud = verify_aud and audience is not None``), so a JWT minted for ANY
+mesh service is accepted as this service's caller. This is a library-wide
+exposure — every consumer that constructs an AuthGuard without an audience is
+affected — and, before this change, it happened silently.
 
-The fix is deliberately NON-BREAKING on upgrade: it ALWAYS warns when audience
-verification is disabled, but only RAISES ``ConfigurationError`` when the service
-declares a production/staging environment (ambient ``ENVIRONMENT`` /
-``AB0T_AUTH_ENVIRONMENT``) and ``AB0T_AUTH_DEBUG`` is not set. A dev/test/unset
-environment is warn-only, so existing consumers keep working.
+The fix is BACKWARD-COMPATIBLE (additive):
+  * ALWAYS: a loud warning is logged when audience verification is disabled.
+    Construction still succeeds — the default behaviour is unchanged, so upgrading
+    the library cannot break any existing consumer.
+  * OPT-IN fail-closed: ``require_audience=True`` (constructor) or the env var
+    ``AB0T_AUTH_REQUIRE_AUDIENCE=true`` turns the audience-less configuration into
+    a hard ``ConfigurationError`` at construction. Off by default, mirroring how
+    auth-bypass is opt-in rather than imposed.
 
-Negative-control law: the prod-refusal assertion fails if
-``_enforce_audience_security`` is reverted to a no-op.
+Negative-control law: the opt-in-refusal assertions fail if
+``_warn_or_require_audience`` is reverted to a no-op.
 """
 import pytest
 
@@ -28,50 +31,53 @@ URL = "https://auth.service.ab0t.com"
 
 @pytest.fixture(autouse=True)
 def _clean_env(monkeypatch):
-    # Ensure no ambient env leaks into the tests.
-    for k in ("AB0T_AUTH_DEBUG", "AB0T_AUTH_BYPASS", "ENVIRONMENT", "AB0T_AUTH_ENVIRONMENT"):
+    for k in ("AB0T_AUTH_DEBUG", "AB0T_AUTH_BYPASS", "AB0T_AUTH_REQUIRE_AUDIENCE"):
         monkeypatch.delenv(k, raising=False)
 
 
-class TestAudienceSecurity:
-    @pytest.mark.parametrize("env", ["production", "prod", "staging"])
-    def test_prodlike_without_audience_is_refused(self, monkeypatch, env):
-        """The core control: no audience in a prod-like env => refuse to construct.
-        RED if the guard is reverted (constructs wide open)."""
-        monkeypatch.setenv("ENVIRONMENT", env)
-        with pytest.raises(ConfigurationError) as ei:
-            AuthGuard(auth_url=URL)  # audience defaults to None
-        assert ei.value.details == {"config_key": "audience"}
+class TestAudienceBackwardCompatible:
+    """The DEFAULT must not change: audience-less construction still succeeds."""
 
-    def test_prod_via_ab0t_env_var_also_refused(self, monkeypatch):
-        """The AB0T_AUTH_ENVIRONMENT signal is honored the same as ENVIRONMENT."""
-        monkeypatch.setenv("AB0T_AUTH_ENVIRONMENT", "production")
-        with pytest.raises(ConfigurationError):
-            AuthGuard(auth_url=URL)
+    def test_default_no_audience_still_constructs(self):
+        """No audience + no opt-in => constructs (warn-only). This is the contract
+        every existing consumer relies on; it must not regress."""
+        guard = AuthGuard(auth_url=URL)  # audience defaults to None
+        assert guard.config.audience is None
 
-    def test_prodlike_with_audience_constructs(self, monkeypatch):
-        """Fix does not over-block: a configured audience constructs fine in prod."""
-        monkeypatch.setenv("ENVIRONMENT", "production")
+    def test_default_with_audience_constructs(self):
         guard = AuthGuard(auth_url=URL, audience=AUD)
         assert guard.config.audience == AUD
         assert guard.config.verify_aud is True
 
-    def test_prod_with_debug_is_allowed(self, monkeypatch):
-        """DEBUG escape hatch: audience-less is permitted even in prod when
-        AB0T_AUTH_DEBUG=true (dev-on-prod-config), matching the bypass pattern."""
-        monkeypatch.setenv("ENVIRONMENT", "production")
-        monkeypatch.setenv("AB0T_AUTH_DEBUG", "true")
-        guard = AuthGuard(auth_url=URL)
-        assert guard.config.audience is None
 
-    def test_dev_without_audience_is_allowed_warn_only(self):
-        """NON-BREAKING: a dev/unset environment is warn-only, never a hard error —
-        so existing consumers are not broken by upgrading the library."""
-        guard = AuthGuard(auth_url=URL)  # no ENVIRONMENT, no audience
-        assert guard.config.audience is None
+class TestAudienceOptInStrict:
+    """require_audience is an OPT-IN fail-closed knob."""
 
-    def test_prodlike_with_multi_audience_tuple_constructs(self, monkeypatch):
-        """A tuple audience (multi-aud service) also satisfies the guard in prod."""
-        monkeypatch.setenv("ENVIRONMENT", "production")
-        guard = AuthGuard(auth_url=URL, audience=(AUD, "LOCAL:other"))
+    def test_require_audience_kwarg_without_audience_raises(self):
+        """The core control: opt-in strict + no audience => refuse to construct.
+        RED if the guard is reverted to a no-op."""
+        with pytest.raises(ConfigurationError) as ei:
+            AuthGuard(auth_url=URL, require_audience=True)
+        assert ei.value.details == {"config_key": "audience"}
+
+    def test_require_audience_env_without_audience_raises(self, monkeypatch):
+        """The AB0T_AUTH_REQUIRE_AUDIENCE env var is an equivalent opt-in signal."""
+        monkeypatch.setenv("AB0T_AUTH_REQUIRE_AUDIENCE", "true")
+        with pytest.raises(ConfigurationError):
+            AuthGuard(auth_url=URL)
+
+    def test_require_audience_with_audience_constructs(self):
+        """Opt-in strict does not over-block once an audience is configured."""
+        guard = AuthGuard(auth_url=URL, audience=AUD, require_audience=True)
+        assert guard.config.audience == AUD
+
+    def test_require_audience_with_tuple_audience_constructs(self):
+        """A tuple audience (multi-aud service) satisfies the strict check."""
+        guard = AuthGuard(auth_url=URL, audience=(AUD, "LOCAL:other"), require_audience=True)
         assert guard.config.audience == (AUD, "LOCAL:other")
+
+    def test_require_audience_env_false_does_not_opt_in(self, monkeypatch):
+        """Only an explicit 'true' opts in; other values leave the default (no raise)."""
+        monkeypatch.setenv("AB0T_AUTH_REQUIRE_AUDIENCE", "false")
+        guard = AuthGuard(auth_url=URL)  # not opted in
+        assert guard.config.audience is None

--- a/tickets/ISSUE-017-audience-verification-silently-disabled.md
+++ b/tickets/ISSUE-017-audience-verification-silently-disabled.md
@@ -1,0 +1,97 @@
+# ISSUE-017: JWT audience verification is silently disabled when no audience is configured
+
+## Summary
+
+When an `AuthGuard` is constructed without an `audience` (or with `verify_aud=False`), the library
+**silently accepts a JWT minted for ANY service in the mesh** as this service's caller. The audience claim
+(`aud`, e.g. `LOCAL:<org_uuid>`) is the boundary that stops a token issued for service X being replayed
+against service Y. There is no guard against running this way — a single unset/forgotten audience runs the
+service wide open, with no error and (before this fix) no warning.
+
+## Severity
+
+**High** — cross-service token confusion. Any mesh service that forgets to set its audience accepts tokens
+minted for a *different* service/org. Because the wrapper is shared by every service, this is a fleet-wide
+exposure, not a single-service bug.
+
+## Affected Versions
+
+- All versions. The wrapper defaults `audience=None`, and PyJWT is told not to verify the claim when the
+  expected audience is absent.
+
+## Root Cause Analysis
+
+### The bug location
+
+`src/ab0t_auth/jwt.py`, `validate_token_local()` builds the PyJWT decode options as:
+
+```python
+"verify_aud": config.verify_aud and config.audience is not None,
+```
+
+When `config.audience is None`, `verify_aud` collapses to `False` and PyJWT does **not** validate `aud`.
+Nothing at construction time flags or refuses this configuration, unlike the auth-bypass path which is
+gated behind a defense-in-depth flag (`load_bypass_config()` requires `AB0T_AUTH_BYPASS=true` **and**
+`AB0T_AUTH_DEBUG=true`).
+
+### Flow breakdown
+
+```
+1. Service constructs AuthGuard(auth_url=...) with no audience (or AB0T_AUTH_AUDIENCE unset).
+2. config.audience is None → decode option verify_aud = (True and None is not None) = False.
+3. A token minted for a DIFFERENT service (different aud) is signed by the same mesh JWKS.
+4. jwt.decode() skips the aud check → token is accepted.
+5. The request is authorized as this service's caller, using the foreign token's org_id/user_id.
+```
+
+### Why it went unnoticed
+
+`verify_aud` defaults to `True`, which reads as "audience is verified" — but it is a no-op unless an
+`audience` is also supplied. The two settings must agree, and nothing enforced that they do.
+
+## Fix
+
+`src/ab0t_auth/guard.py` — new `AuthGuard._enforce_audience_security()`, called at construction.
+Deliberately **non-breaking on upgrade**, two tiers:
+
+1. **Always** emit a loud `logger.warning("audience_verification_disabled", …)` whenever audience
+   verification is off — so the exposure is visible in every environment.
+2. **Fail closed** (`raise ConfigurationError`) **only** when the service declares a production/staging
+   environment via `ENVIRONMENT` / `AB0T_AUTH_ENVIRONMENT` **and** `AB0T_AUTH_DEBUG` is not set. A
+   dev/test/unset environment is warn-only, so upgrading the library does not break existing consumers —
+   only a *production deployment that forgot its audience* is stopped at boot.
+
+Mirrors the existing bypass defense-in-depth: the dangerous mode is only reachable behind an explicit
+signal. Clearing it is one line — set the service's audience (`AB0T_AUTH_AUDIENCE` / `audience=`).
+
+### Why not fail hard regardless of environment?
+
+A first draft raised whenever `AB0T_AUTH_DEBUG` was absent. That broke **19** of the library's own tests,
+which legitimately construct audience-less guards in unit tests. The shipped, env-gated form keeps the full
+suite green.
+
+## Testing
+
+`tests/test_audience_security.py` (8 tests):
+
+- Prod-like env (`ENVIRONMENT` ∈ {production, prod, staging}) + no audience → `ConfigurationError` (RED if
+  the guard is reverted to a no-op: the 4 prod-refusal cases stop raising).
+- Prod-like env + audience set (str or tuple) → constructs fine (no over-block).
+- Prod-like env + `AB0T_AUTH_DEBUG=true` → allowed (escape hatch, matches bypass).
+- Dev / unset env + no audience → allowed, warn-only (non-breaking).
+
+Full suite: **466 passed** (with `flask` + `respx` installed so nothing is skipped) — the fix adds no
+regressions.
+
+## Rollout note (IMPORTANT — coordinated release)
+
+Because prod services set `ENVIRONMENT`, a service running in production **with no audience configured will
+now fail fast at boot**. That is the intended behavior, but it means each mesh consumer must set its
+`AB0T_AUTH_AUDIENCE` **before** this release reaches its production environment. Recommend confirming
+audience is set for every consumer, then releasing.
+
+## Reported by
+
+Resource-service security audit (R-M2, 2026-07-12/13). The per-service interim guard
+(`resource/output/app/auth.py::_resolve_audience`) is deployed as defense-in-depth; this issue generalizes
+that guarantee to every consumer of the shared wrapper.

--- a/tickets/ISSUE-017-audience-verification-silently-disabled.md
+++ b/tickets/ISSUE-017-audience-verification-silently-disabled.md
@@ -51,44 +51,61 @@ gated behind a defense-in-depth flag (`load_bypass_config()` requires `AB0T_AUTH
 
 ## Fix
 
-`src/ab0t_auth/guard.py` — new `AuthGuard._enforce_audience_security()`, called at construction.
-Deliberately **non-breaking on upgrade**, two tiers:
+`src/ab0t_auth/guard.py` — new `AuthGuard._warn_or_require_audience()`, called at construction. Designed as
+a **backward-compatible, additive** change (no contract break — a minor-version feature, not a breaking one):
 
 1. **Always** emit a loud `logger.warning("audience_verification_disabled", …)` whenever audience
-   verification is off — so the exposure is visible in every environment.
-2. **Fail closed** (`raise ConfigurationError`) **only** when the service declares a production/staging
-   environment via `ENVIRONMENT` / `AB0T_AUTH_ENVIRONMENT` **and** `AB0T_AUTH_DEBUG` is not set. A
-   dev/test/unset environment is warn-only, so upgrading the library does not break existing consumers —
-   only a *production deployment that forgot its audience* is stopped at boot.
+   verification is off. **Construction still succeeds by default** — the historical behaviour is preserved,
+   so upgrading the library cannot break any existing consumer.
+2. **Opt-in fail-closed** — a new constructor kwarg `require_audience: bool = False` **and** env var
+   `AB0T_AUTH_REQUIRE_AUDIENCE=true`. When either is set, an audience-less configuration raises
+   `ConfigurationError` at construction. Off by default.
 
-Mirrors the existing bypass defense-in-depth: the dangerous mode is only reachable behind an explicit
-signal. Clearing it is one line — set the service's audience (`AB0T_AUTH_AUDIENCE` / `audience=`).
+This mirrors the auth-bypass philosophy correctly: the stricter/dangerous posture is **opt-in**, never
+imposed. A security-conscious service (or a deployment's prod config) turns `AB0T_AUTH_REQUIRE_AUDIENCE=true`
+on to get the fail-closed guarantee; everyone else gets the visibility of the warning with zero behaviour
+change. Clearing the warning entirely is one line — set the service's audience (`AB0T_AUTH_AUDIENCE` /
+`audience=`).
 
-### Why not fail hard regardless of environment?
+### Why additive rather than a stricter default?
 
-A first draft raised whenever `AB0T_AUTH_DEBUG` was absent. That broke **19** of the library's own tests,
-which legitimately construct audience-less guards in unit tests. The shipped, env-gated form keeps the full
-suite green.
+The wrapper is used by many services; `AuthGuard(auth_url=...)` with no audience has always constructed
+successfully (the library's own tests do so 19×). Making that raise — even gated on an ambient `ENVIRONMENT`
+var the library did not previously read — is a silent contract change that would fail existing prod
+deployments on a patch bump. Per best-practice engineering, a behaviour break must be a deliberate,
+documented, version-gated contract change. This PR ships the safe, non-breaking layer (warn + opt-in);
+if the team later wants `require_audience` to default `True`, that is a documented **major** release with a
+migration note — the maintainers' call, not a side effect of a security patch.
+
+### Public API surface added (backward compatible)
+
+- `AuthGuard(..., require_audience: bool = False)` — new optional kwarg.
+- `AB0T_AUTH_REQUIRE_AUDIENCE` — new env var (read directly in the guard; covers `settings=`/env-driven
+  construction without touching the frozen `AuthConfig`/`AuthSettings`).
+- A new `warning` log event `audience_verification_disabled`.
 
 ## Testing
 
-`tests/test_audience_security.py` (8 tests):
+`tests/test_audience_security.py` (7 tests):
 
-- Prod-like env (`ENVIRONMENT` ∈ {production, prod, staging}) + no audience → `ConfigurationError` (RED if
-  the guard is reverted to a no-op: the 4 prod-refusal cases stop raising).
-- Prod-like env + audience set (str or tuple) → constructs fine (no over-block).
-- Prod-like env + `AB0T_AUTH_DEBUG=true` → allowed (escape hatch, matches bypass).
-- Dev / unset env + no audience → allowed, warn-only (non-breaking).
+- **Backward-compat:** no audience + no opt-in → constructs (warn-only); with audience → constructs. These
+  pin the contract existing consumers rely on.
+- **Opt-in strict:** `require_audience=True` (kwarg) or `AB0T_AUTH_REQUIRE_AUDIENCE=true` (env) + no audience
+  → `ConfigurationError` (RED if the guard is reverted to a no-op); with audience (str or tuple) → constructs;
+  `=false` env does not opt in.
 
-Full suite: **466 passed** (with `flask` + `respx` installed so nothing is skipped) — the fix adds no
-regressions.
+Full suite: **465 passed** (with `flask` + `respx` installed so nothing is skipped) — no regressions; every
+existing audience-less construction test still passes because the default is unchanged.
 
-## Rollout note (IMPORTANT — coordinated release)
+## Rollout note (non-breaking)
 
-Because prod services set `ENVIRONMENT`, a service running in production **with no audience configured will
-now fail fast at boot**. That is the intended behavior, but it means each mesh consumer must set its
-`AB0T_AUTH_AUDIENCE` **before** this release reaches its production environment. Recommend confirming
-audience is set for every consumer, then releasing.
+Nothing is forced. On upgrade, consumers that already set `AB0T_AUTH_AUDIENCE` see no change; consumers
+without it get a new loud warning at startup. To adopt the guarantee, a service sets
+`AB0T_AUTH_REQUIRE_AUDIENCE=true` (recommended for prod) **after** confirming its `AB0T_AUTH_AUDIENCE` is set.
+A fleet audit of `production/.env.production` across the mesh (2026-07-13) found audience set for every
+wrapper-consuming service (billing/banking/integration/payment/resource/sandbox-platform/schema/tool
+explicitly; audit via its config default) — so enabling `AB0T_AUTH_REQUIRE_AUDIENCE` is currently safe
+everywhere.
 
 ## Reported by
 


### PR DESCRIPTION
## ISSUE-017 — surface (and optionally enforce) JWT audience verification

### The exposure
`validate_token_local` (`jwt.py`) builds PyJWT options as
`"verify_aud": config.verify_aud and config.audience is not None`. When an `AuthGuard` is constructed
without an `audience`, `verify_aud` collapses to `False` and PyJWT **skips the `aud` check** — so a token
minted for **any** mesh service is accepted as this service's caller. Shared wrapper ⇒ fleet-wide
cross-service token confusion, and it happened **silently**.

### The fix — additive, backward-compatible (not a silent contract break)
`AuthGuard._warn_or_require_audience()`, called at construction:

1. **Always warn** — logs `warning("audience_verification_disabled", …)` when audience verification is off.
   **Construction still succeeds by default → zero behaviour change for existing consumers.**
2. **Opt-in fail-closed** — new kwarg `require_audience: bool = False` and env `AB0T_AUTH_REQUIRE_AUDIENCE`.
   When enabled, an audience-less config raises `ConfigurationError`. **Off by default**, mirroring how
   auth-bypass is opt-in rather than imposed.

> **Revised after review.** The first commit read an ambient `ENVIRONMENT` var the library never read and
> **raised in prod** for an audience-less config that has always been valid — a silent contract change that
> could fail existing prod deployments on a patch bump. That's not best-practice for a shared lib, so it's
> been reworked to this additive form. Making `require_audience` default `True` would be a separately
> documented **major** release — the maintainers' call, not a side effect of a security patch.

### Public API added (minor, backward compatible)
- `AuthGuard(..., require_audience=False)` kwarg
- `AB0T_AUTH_REQUIRE_AUDIENCE` env var (covers `settings=`/env-driven construction; no `AuthConfig`/`AuthSettings` churn)
- new `warning` event `audience_verification_disabled`

### Testing
- `tests/test_audience_security.py` (7): backward-compat construction (no audience + no opt-in → constructs)
  and opt-in strict (kwarg/env → raises; RED if the guard is reverted to a no-op).
- Full suite **465 passed** (flask+respx installed, nothing skipped); every existing audience-less
  construction test still passes because the default is unchanged.

### Rollout (non-breaking)
Nothing is forced. Consumers that already set `AB0T_AUTH_AUDIENCE` see no change; others get a new startup
warning. To adopt the guarantee, set `AB0T_AUTH_REQUIRE_AUDIENCE=true` (recommended for prod) after
confirming `AB0T_AUTH_AUDIENCE` is set. A 2026-07-13 fleet audit of `production/.env.production` found
audience set for every wrapper-consuming mesh service, so enabling it is currently safe everywhere.

Ticket: `tickets/ISSUE-017-audience-verification-silently-disabled.md`. Reported by the resource-service
security audit (R-M2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
